### PR TITLE
Add backend API for P&ID tag extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# ahmed
+# P&ID Tag Extractor
+
+This repository contains a simple script for extracting equipment, valve, and piping tags from P&ID PDF or DXF (CAD) files.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python pid_parser.py path/to/file.pdf
+# or for DXF
+python pid_parser.py path/to/file.dxf --output tags.csv
+```
+
+The script prints a table of tags, their inferred category, and description (text on the same line). When the `--output` option
+is used, results are written to a CSV file.
+
+## Backend API
+
+Start a web server that accepts file uploads and returns extracted tags as JSON:
+
+```bash
+uvicorn backend:app --reload
+```
+
+Then upload a file with any HTTP client:
+
+```bash
+curl -F "file=@path/to/file.pdf" http://localhost:8000/parse
+```

--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI, File, UploadFile
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+import shutil
+from pid_parser import extract
+
+app = FastAPI()
+
+
+@app.post("/parse")
+async def parse_file(file: UploadFile = File(...)):
+    """Parse an uploaded P&ID file and return extracted tags."""
+    suffix = Path(file.filename).suffix
+    with NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        shutil.copyfileobj(file.file, tmp)
+        temp_path = Path(tmp.name)
+    try:
+        rows = extract(temp_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+    return {"items": rows}

--- a/pid_parser.py
+++ b/pid_parser.py
@@ -1,0 +1,88 @@
+import argparse
+import csv
+import re
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+import pdfplumber
+import ezdxf
+
+TAG_PATTERN = re.compile(r"(?P<tag>[A-Z]{1,5}[- ]?\d+[A-Z]*)")
+
+
+def extract_from_pdf(path: Path) -> List[Dict[str, str]]:
+    """Extract tag information from a PDF file."""
+    results = []
+    with pdfplumber.open(str(path)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            for line in text.splitlines():
+                match = TAG_PATTERN.search(line)
+                if match:
+                    tag = match.group("tag").replace(" ", "")
+                    description = line.replace(match.group("tag"), "").strip()
+                    results.append({"tag": tag, "description": description})
+    return results
+
+
+def extract_from_dxf(path: Path) -> List[Dict[str, str]]:
+    """Extract tag information from a DXF (CAD) file."""
+    results = []
+    doc = ezdxf.readfile(str(path))
+    for entity in doc.modelspace():
+        if entity.dxftype() in {"TEXT", "MTEXT"}:
+            text = entity.plain_text() if entity.dxftype() == "MTEXT" else entity.text
+            match = TAG_PATTERN.search(text)
+            if match:
+                tag = match.group("tag").replace(" ", "")
+                description = text.replace(match.group("tag"), "").strip()
+                results.append({"tag": tag, "description": description})
+    return results
+
+
+CATEGORY_RULES = {
+    "equipment": re.compile(r"^E"),
+    "valve": re.compile(r"^V"),
+    "piping": re.compile(r"^P"),
+}
+
+
+def categorize(tag: str) -> str:
+    for category, pattern in CATEGORY_RULES.items():
+        if pattern.match(tag):
+            return category
+    return "unknown"
+
+
+def extract(path: Path) -> List[Dict[str, str]]:
+    if path.suffix.lower() == ".pdf":
+        entries = extract_from_pdf(path)
+    elif path.suffix.lower() in {".dxf"}:
+        entries = extract_from_dxf(path)
+    else:
+        raise ValueError(f"Unsupported file type: {path.suffix}")
+    for entry in entries:
+        entry["category"] = categorize(entry["tag"])
+    return entries
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract tags from P&ID files.")
+    parser.add_argument("input", type=Path, help="Path to PDF or DXF file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional CSV output file; prints table if omitted",
+    )
+    args = parser.parse_args()
+
+    rows = extract(args.input)
+    if args.output:
+        with args.output.open("w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=["tag", "category", "description"])
+            writer.writeheader()
+            writer.writerows(rows)
+    else:
+        for row in rows:
+            print(f"{row['tag']}, {row['category']}, {row['description']}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pdfplumber
+ezdxf
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- Create `backend.py` FastAPI service to parse uploaded P&ID files and return tags
- Document backend startup and usage
- Include FastAPI and Uvicorn dependencies

## Testing
- `python -m py_compile pid_parser.py backend.py`
- `python pid_parser.py --help`
- `uvicorn backend:app --help`


------
https://chatgpt.com/codex/tasks/task_e_68c5531280cc832f812e97415db66b92